### PR TITLE
Remove unmanaged.feed_enable() call from the robot code

### DIFF
--- a/armbot_phoenix6/subsystems/armsubsystem.py
+++ b/armbot_phoenix6/subsystems/armsubsystem.py
@@ -85,9 +85,6 @@ class ArmSubsystem(commands2.ProfiledPIDSubsystem):
         request = controls.VoltageOut(0)
         self.talonfx.set_control(request.with_output(motor_voltage))
 
-        # This is required to enable the Falcon 500 during simulation
-        unmanaged.feed_enable(100)
-
     def getMeasurement(self) -> float:
         """Returns the position of the arm in radians"""
         rotations = self.talonfx.get_position().value


### PR DESCRIPTION
Removed the unmanaged.feed_enable() call from the robot code. It is still in the simulation code.